### PR TITLE
Take over Materialize development

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -924,8 +924,7 @@
 		},
 		{
 			"name": "Materialize",
-			"previous_names": ["Material Spacegray"],
-			"details": "https://github.com/saadq/Materialize",
+			"details": "https://github.com/zyphlar/Materialize",
 			"labels": ["theme", "color scheme", "material"],
 			"releases": [
 				{


### PR DESCRIPTION
The existing repo has been archived for 4 years and lacking activity for 7; I've merged an open PR enabling colored title bars and published to Github.

- [x] I'm the package's ***new*** author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.

My package is a theme

My package is a fork of Materialize, however it should still be added because the existing Materialize has been abandoned and marked as archived for a long time.


